### PR TITLE
Fix issue with merge processor

### DIFF
--- a/src/DataEnricher/Processor/Merge.php
+++ b/src/DataEnricher/Processor/Merge.php
@@ -19,25 +19,54 @@ class Merge implements Processor
      */
     public function applyToNode(Node $node)
     {
-        $list = $node->getInstruction($this);
+        $instruction = $node->getInstruction($this);
+        
+        $list = $this->resolve($instruction);
         
         $result = $this->merge($list);
         $node->setResult($result);
     }
     
     /**
+     * Resolve processing nodes in the instruction
+     * 
+     * @param array $list
+     * @return array
+     */
+    public function resolve($list)
+    {
+        if ($list instanceof Node) {
+            $list = $list->getResult();
+        }
+        
+        foreach ($list as &$item) {
+            if ($item instanceof Node) {
+                $item = $item->getResult();
+            }
+        }
+        
+        return $list;
+    }
+    
+    /**
      * Merge properties of an object
      * 
-     * @param array $merge
+     * @param array $list
+     * @return \stdClass|array
      */
-    protected function merge($merge)
+    protected function merge(array $list)
     {
-        $result = (object)[];
-        
-        foreach ($merge as $object) { 
-            foreach ($object as $key => $value) {
-               $result->$key = $value;
+        foreach ($list as &$item) {
+            if (is_object($item)) {
+                $item = get_object_vars($item);
             }
+        }
+        
+        $result = call_user_func_array('array_merge', $list);
+        
+        // Is associative array
+        if (array_keys($result) !== array_keys(array_keys($result))) {
+            $result = (object)$result;
         }
         
         return $result;

--- a/tests/DataEnricher/Processor/MergeTest.php
+++ b/tests/DataEnricher/Processor/MergeTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace LegalThings\DataEnricher\Processor;
+
+use LegalThings\DataEnricher\Node;
+use LegalThings\DataEnricher\Processor;
+
+/**
+ * @covers LegalThings\DataEnricher\Processor\Merge
+ */
+class MergeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testApplyToNodeWithObjects()
+    {
+        $first = ['foo' => 'red', 'bar' => 'Sir'];
+        $second = (object)['bird' => 'duck', 'mammal' => 'monkey'];
+
+        $processor = new Processor\Merge('<merge>');
+        $node = $this->getMockBuilder(Node::class)
+            ->disableOriginalConstructor()
+            ->disableProxyingToOriginalMethods()
+            ->getMock();
+
+        $node->expects($this->atLeastOnce())
+            ->method('getInstruction')
+            ->with($processor)
+            ->willReturn([$first, $second]);
+        
+        $node->expects($this->atLeastOnce())
+            ->method('setResult')
+            ->with((object)['foo' => 'red', 'bar' => 'Sir', 'bird' => 'duck', 'mammal' => 'monkey']);
+        
+        $processor->applyToNode($node);
+    }
+    
+    public function testApplyToNodeWithArrays()
+    {
+        $first = ['red', 'Sir'];
+        $second = ['duck', 'monkey'];
+
+        $processor = new Processor\Merge('<merge>');
+        $node = $this->getMockBuilder(Node::class)
+            ->disableOriginalConstructor()
+            ->disableProxyingToOriginalMethods()
+            ->getMock();
+
+        $node->expects($this->atLeastOnce())
+            ->method('getInstruction')
+            ->with($processor)
+            ->willReturn([$first, $second]);
+        
+        $node->expects($this->atLeastOnce())
+            ->method('setResult')
+            ->with(['red', 'Sir', 'duck', 'monkey']);
+        
+        $processor->applyToNode($node);
+    }
+    
+    public function testApplyToNodeWithRefNode()
+    {
+        $refNode = $this->getMockBuilder(Node::class)
+            ->disableOriginalConstructor()
+            ->disableProxyingToOriginalMethods()
+            ->getMock();
+        
+        $data = new \stdClass;
+        $data->foo = 'red';
+        $data->bar = 'Sir';
+        
+        $refNode->expects($this->atLeastOnce())
+            ->method('getResult')
+            ->willReturn($data);
+        
+        $processor = new Processor\Merge('<merge>');
+        $node = $this->getMockBuilder(Node::class)
+            ->disableOriginalConstructor()
+            ->disableProxyingToOriginalMethods()
+            ->getMock();
+
+        $node->expects($this->atLeastOnce())
+            ->method('getInstruction')
+            ->with($processor)
+            ->willReturn([
+                $refNode,
+                (object)[
+                    'bird' => 'duck',
+                    'mammal' => 'monkey'
+                ]
+            ]);
+        
+        $node->expects($this->atLeastOnce())
+            ->method('setResult')
+            ->with((object)['foo' => 'red', 'bar' => 'Sir', 'bird' => 'duck', 'mammal' => 'monkey']);
+        
+        $processor->applyToNode($node);
+    }
+}


### PR DESCRIPTION
Fix issue with merge processor not working with if instruction contains processing nodes

Merge now also works for numeric arrays
Added some tests for merge processor