### PR TITLE
Support multiple args in transform enricher, added hash_hmac

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ Enrich objects by processing special properties known as data instruction.
 * `<enrich>` - Enrich an object with extra data by matching properties
 * `<tpl>` - Parse text as [Mustache](https://mustache.github.io/) template
 * `<transform>` - Transform the input using a function. The following functions are available
+                  You can pass in a string with the following format `<function>:<arg>`
+                  Alternatively you can pass in an object to pass multiple args `{ function: <string>, args: [...] }`
   * [`hash:algo`](http://php.net/hash) - Replace `algo` with the algoritm
+  * [`hash_hmac`](http://php.net/hash_hmac)
   * [`base64_encode`](http://php.net/base64_encode)
   * [`base64_decode`](http://php.net/base64_decode)
   * [`json_encode`](http://php.net/json_encode)

--- a/tests/DataEnricher/Processor/TransformTest.php
+++ b/tests/DataEnricher/Processor/TransformTest.php
@@ -61,6 +61,48 @@ class TransformTest extends \PHPUnit_Framework_TestCase
         $this->processor->applyToNode($node);
     }
     
+    public function testApplyToNodeWithObjectForTransformation()
+    {
+        $node = $this->createMock(Node::class);
+        
+        $node->expects($this->atLeastOnce())
+            ->method('getInstruction')
+            ->with($this->processor)
+            ->willReturn([
+                (object)[
+                    'function' => 'hash',
+                    'args' => ['sha256', 'test']
+                ]
+            ]);
+        
+        $node->expects($this->atLeastOnce())
+            ->method('setResult')
+            ->with(hash('sha256', 'test'));
+        
+        $this->processor->applyToNode($node);
+    }
+    
+    public function testApplyToNodeWithHashHmac()
+    {
+        $node = $this->createMock(Node::class);
+        
+        $node->expects($this->atLeastOnce())
+            ->method('getInstruction')
+            ->with($this->processor)
+            ->willReturn([
+                (object)[
+                    'function' => 'hash_hmac',
+                    'args' => ['sha256', 'data', 'secret']
+                ]
+            ]);
+        
+        $node->expects($this->atLeastOnce())
+            ->method('setResult')
+            ->with(hash_hmac('sha256', 'data', 'secret'));
+        
+        $this->processor->applyToNode($node);
+    }
+    
     public function testApplyToNodeWithObjectForStrToTimeConversion()
     {
         $node = $this->createMock(Node::class);


### PR DESCRIPTION
`<transform>` now supports both string (with single value argument) or object, which can support multiple arguments of different types than just strings.

```json
{
  "<transform>": "hash:sha256",
  "input": "data"
}
```

```json
{
  "<transform>": {
    "function": "hash_hmac",
    "args": ["sha256", "data", "secret"]
  }
}
```