### PR TITLE
Enricher schema

### DIFF
--- a/src/DataEnricher.php
+++ b/src/DataEnricher.php
@@ -29,6 +29,7 @@ class DataEnricher
         '<enrich>' => Processor\Enrich::class,
         '<dateformat>' => Processor\DateFormat::class,
         '<equal>' => Processor\Equal::class,
+        '<match>' => Processor\Match::class,
         
         // Deprecated
         '_ref' => Processor\Reference::class,

--- a/src/DataEnricher.php
+++ b/src/DataEnricher.php
@@ -23,6 +23,7 @@ class DataEnricher
         '<tpl>' => Processor\Mustache::class,
         '<src>' => Processor\Http::class,
         '<jmespath>' => Processor\JmesPath::class,
+        '<apply>' => Processor\JmesPath::class,
         '<transformation>' => Processor\Transform::class,
         '<math>' => Processor\Math::class,
         '<enrich>' => Processor\Enrich::class,

--- a/src/DataEnricher.php
+++ b/src/DataEnricher.php
@@ -30,6 +30,7 @@ class DataEnricher
         '<dateformat>' => Processor\DateFormat::class,
         '<equal>' => Processor\Equal::class,
         '<match>' => Processor\Match::class,
+        '<if>' => Processor\IfElse::class,
         
         // Deprecated
         '_ref' => Processor\Reference::class,

--- a/src/DataEnricher.php
+++ b/src/DataEnricher.php
@@ -28,6 +28,7 @@ class DataEnricher
         '<math>' => Processor\Math::class,
         '<enrich>' => Processor\Enrich::class,
         '<dateformat>' => Processor\DateFormat::class,
+        '<equal>' => Processor\Equal::class,
         
         // Deprecated
         '_ref' => Processor\Reference::class,

--- a/src/DataEnricher/Processor/Equal.php
+++ b/src/DataEnricher/Processor/Equal.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace LegalThings\DataEnricher\Processor;
+
+use LegalThings\DataEnricher\Node;
+use LegalThings\DataEnricher\Processor;
+
+/**
+ * Equal processor
+ */
+class Equal implements Processor
+{
+    use Processor\Implementation;
+    
+    /**
+     * Apply processing to a single node
+     * 
+     * @param Node $node
+     */
+    public function applyToNode(Node $node)
+    {
+        $instruction = $node->getInstruction($this);
+        
+        if (!is_array($instruction) || count($instruction) !== 2) {
+            $node->setResult(false);
+        }
+        
+        // might want to improve this check for different types using a library
+        $node->setResult($instruction[0] == $instruction[1]);
+    }
+}

--- a/src/DataEnricher/Processor/IfElse.php
+++ b/src/DataEnricher/Processor/IfElse.php
@@ -6,9 +6,9 @@ use LegalThings\DataEnricher\Node;
 use LegalThings\DataEnricher\Processor;
 
 /**
- * Match processor
+ * IfElse processor
  */
-class Match implements Processor
+class IfElse implements Processor
 {
     use Processor\Implementation;
     
@@ -25,19 +25,14 @@ class Match implements Processor
             $instruction = (object)$instruction;
         }
         
-        if (!isset($instruction) || !isset($instruction->input)) {
+        if (!isset($instruction) || !isset($instruction->condition)) {
             return;
         }
         
-        if (!isset($instruction->find) && !isset($instruction->regex)) {
-            return;
-        }
-        
-        if (isset($instruction->find)) {
-            $result = strpos($instruction->input, $instruction->find) !== false;
+        if ($instruction->condition) {
+            $result = isset($instruction->then) ? $instruction->then : $node->getResult();
         } else {
-            $flags = isset($instruction->flags) ? $instruction->flags : 0;
-            $result = preg_match($instruction->regex, $instruction->input, $matches, $flags);
+            $result = isset($instruction->else) ? $instruction->else : null;
         }
         
         $node->setResult($result);

--- a/src/DataEnricher/Processor/JmesPath.php
+++ b/src/DataEnricher/Processor/JmesPath.php
@@ -22,10 +22,16 @@ class JmesPath implements Processor
      */
     public function applyToNode(Node $node)
     {
-        $path = $node->getInstruction($this);
-        $input = $node->getResult();
+        $instruction = $node->getInstruction($this);
         
-        $result = jmespath_search($path, $input);
+        if (is_array($instruction) || is_object($instruction)) {
+            $instruction = (object)$instruction;
+        }
+        
+        $input = is_string($instruction) ? $node->getResult() : $instruction->input;
+        $query = is_string($instruction) ? $instruction : $instruction->query;
+        
+        $result = jmespath_search($query, $input);
         static::objectivy($result);
         
         $node->setResult($result);

--- a/src/DataEnricher/Processor/Match.php
+++ b/src/DataEnricher/Processor/Match.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace LegalThings\DataEnricher\Processor;
+
+use LegalThings\DataEnricher\Node;
+use LegalThings\DataEnricher\Processor;
+
+/**
+ * Match processor
+ */
+class Match implements Processor
+{
+    use Processor\Implementation;
+    
+    /**
+     * Apply processing to a single node
+     * 
+     * @param Node $node
+     */
+    public function applyToNode(Node $node)
+    {
+        $instruction = $node->getInstruction($this);
+        
+        if (is_array($instruction) || is_object($instruction)) {
+            $instruction = (object)$instruction;
+        }
+        
+        if (!isset($instruction) || !isset($instruction->input)) {
+            return;
+        }
+        
+        if (!isset($instruction->find) && !isset($instruction->regex)) {
+            return;
+        }
+        
+        $result = null;
+        
+        if (isset($instruction->find)) {
+            $result = strpos($instruction->input, $instruction->find) !== false;
+        } else {
+            $flags = isset($instruction->flags) ? $instruction->flags : 0;
+            $result = preg_match($instruction->regex, $instruction->input, $matches, $flags);
+        }
+        
+        $node->setResult($result);
+    }
+}

--- a/src/DataEnricher/Processor/Reference.php
+++ b/src/DataEnricher/Processor/Reference.php
@@ -2,31 +2,56 @@
 
 namespace LegalThings\DataEnricher\Processor;
 
-use LegalThings\DataEnricher\Processor;
-use LegalThings\DataEnricher\Processor\Helper;
 use LegalThings\DataEnricher\Node;
+use LegalThings\DataEnricher\Processor;
+use function JmesPath\search as jmespath_search;
+use JmesPath\Utils;
 
 /**
- * Symbolic link to a property of the source object
+ * Reference JMESPath processor
+ * @see http://jmespath.org/
  */
 class Reference implements Processor
 {
-    use Processor\Implementation,
-        Helper\GetByReference
-    {
-        Helper\GetByReference::withSourceAndTarget insteadof Processor\Implementation;
-    }
+    use Processor\Implementation;
     
     /**
-     * Apply reference processing to a single node
+     * Apply processing to a single node
      * 
      * @param Node $node
      */
     public function applyToNode(Node $node)
     {
-        $ref = $node->getInstruction($this);
+        $instruction = $node->getInstruction($this);
         
-        $result = $this->getByReference($ref, $this->source, $this->target);
+        if (is_array($instruction) || is_object($instruction)) {
+            $instruction = (object)$instruction;
+        }
+        
+        $input = is_string($instruction) ? $node->getResult() : $instruction->input;
+        $query = is_string($instruction) ? $instruction : $instruction->query;
+        
+        $result = jmespath_search($query, $input);
+        static::objectivy($result);
+        
         $node->setResult($result);
+    }
+    
+    /**
+     * Cast associated arrays to objects
+     * 
+     * @return mixed
+     */
+    protected static function objectivy(&$value)
+    {
+        if (Utils::isObject($value)) {
+            $value = (object)$value;
+        }
+        
+        if (is_array($value) || is_object($value)) {
+            foreach ($value as &$item) {
+                static::objectivy($item);
+            }
+        }
     }
 }

--- a/tests/DataEnricher/Processor/EqualTest.php
+++ b/tests/DataEnricher/Processor/EqualTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace LegalThings\DataEnricher\Processor;
+
+use LegalThings\DataEnricher\Node;
+use LegalThings\DataEnricher\Processor;
+
+/**
+ * @covers LegalThings\DataEnricher\Processor\Equal
+ */
+class EqualTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Processor\Equal;
+     */
+    protected $processor;
+
+    public function setUp()
+    {
+        $this->processor = new Processor\Equal('<equal>');
+    }
+    
+    public function instructionProvider()
+    {
+        return [
+            [['string1', 'string1'], true],
+            [['string1', 'string2'], false],
+            [[true, true], true],
+            [[false, false], true],
+            [[true, false], false],
+            [[['foo'], ['foo']], true],
+            [[['foo'], ['bar']], false]
+        ];
+    }
+    
+    /**
+     * @dataProvider instructionProvider
+     * 
+     * @param string|object|array $instruction
+     * @param object              $source
+     * @param array|object        $target
+     * @param string|object|array $result
+     */
+    public function testApplyToNode($instruction, $result)
+    {
+        $node = $this->createMock(Node::class);
+        
+        $node->expects($this->atLeastOnce())
+            ->method('getInstruction')
+            ->with($this->processor)
+            ->willReturn($instruction);
+        
+        $node->expects($this->atLeastOnce())
+            ->method('setResult')
+            ->with($result);
+        
+        $this->processor->applyToNode($node);
+    }
+}

--- a/tests/DataEnricher/Processor/IfElseTest.php
+++ b/tests/DataEnricher/Processor/IfElseTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace LegalThings\DataEnricher\Processor;
+
+use LegalThings\DataEnricher\Node;
+use LegalThings\DataEnricher\Processor;
+
+/**
+ * @covers LegalThings\DataEnricher\Processor\IfElse
+ */
+class IfElseTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Processor\IfElse;
+     */
+    protected $processor;
+
+    public function setUp()
+    {
+        $this->processor = new Processor\IfElse('<if>');
+    }
+    
+    public function instructionProvider()
+    {
+        return [
+            [['condition' => true], 'foo', 'foo'],
+            [['condition' => false], 'foo', null],
+            [['condition' => true, 'then' => 'foo'], null, 'foo'],
+            [['condition' => false, 'then' => 'foo'], null, null],
+            [['condition' => true, 'then' => 'foo', 'else' => 'bar'], null, 'foo'],
+            [['condition' => false, 'then' => 'foo', 'else' => 'bar'], null, 'bar']
+        ];
+    }
+    
+    /**
+     * @dataProvider instructionProvider
+     * 
+     * @param $instruction
+     * @param $input
+     * @param $result
+     */
+    public function testApplyToNode($instruction, $input, $result)
+    {
+        $node = $this->createMock(Node::class);
+        
+        $node->expects($this->atLeastOnce())
+            ->method('getInstruction')
+            ->with($this->processor)
+            ->willReturn($instruction);
+        
+        $node->expects($this->any())
+            ->method('getResult')
+            ->willReturn($input);
+        
+        $node->expects($this->atLeastOnce())
+            ->method('setResult')
+            ->with($result);
+        
+        $this->processor->applyToNode($node);
+    }
+}

--- a/tests/DataEnricher/Processor/JmesPathTest.php
+++ b/tests/DataEnricher/Processor/JmesPathTest.php
@@ -12,6 +12,7 @@ class JmesPathTest extends \PHPUnit_Framework_TestCase
 {
     public function testApplyToNodeWithObject()
     {
+        // for bc
         $processor = new Processor\JmesPath('<jmespath>');
         
         $node = $this->createMock(Node::class);
@@ -29,6 +30,35 @@ class JmesPathTest extends \PHPUnit_Framework_TestCase
         $node->expects($this->atLeastOnce())
             ->method('getResult')
             ->willReturn($data);
+        
+        $node->expects($this->atLeastOnce())
+            ->method('setResult')
+            ->with((object)['foo' => 'red', 'title' => 'Sir']);
+        
+        $processor->applyToNode($node);
+    }
+    
+    public function testApplyToNodeWithInputAndQuery()
+    {
+        $processor = new Processor\JmesPath('<apply>');
+        
+        $node = $this->createMock(Node::class);
+        
+        $data = new \stdClass;
+        $data->foo = 'red';
+        $data->bar = 'Sir';
+        $data->qux = 22;
+        
+        $node->expects($this->atLeastOnce())
+            ->method('getInstruction')
+            ->with($processor)
+            ->willReturn([
+                'input' => $data,
+                'query' => '{foo: foo, title: bar}'
+            ]);
+        
+        $node->expects($this->never())
+            ->method('getResult');
         
         $node->expects($this->atLeastOnce())
             ->method('setResult')

--- a/tests/DataEnricher/Processor/MatchTest.php
+++ b/tests/DataEnricher/Processor/MatchTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace LegalThings\DataEnricher\Processor;
+
+use LegalThings\DataEnricher\Node;
+use LegalThings\DataEnricher\Processor;
+
+/**
+ * @covers LegalThings\DataEnricher\Processor\Match
+ */
+class MatchTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Processor\Match;
+     */
+    protected $processor;
+
+    public function setUp()
+    {
+        $this->processor = new Processor\Match('<match>');
+    }
+    
+    public function instructionProvider()
+    {
+        return [
+            [['input' => 'foo/bar/crux', 'find' => 'crux'], true],
+            [['input' => 'foo/bar/', 'find' => 'crux'], false],
+            [['input' => 'foo/bar/crux', 'regex' => '/^foo/'], true],
+            [['input' => 'bar/crux', 'regex' => '/^foo/'], false]
+        ];
+    }
+    
+    /**
+     * @dataProvider instructionProvider
+     * 
+     * @param string|object|array $instruction
+     * @param object              $source
+     * @param array|object        $target
+     * @param string|object|array $result
+     */
+    public function testApplyToNode($instruction, $result)
+    {
+        $node = $this->createMock(Node::class);
+        
+        $node->expects($this->atLeastOnce())
+            ->method('getInstruction')
+            ->with($this->processor)
+            ->willReturn($instruction);
+        
+        $node->expects($this->atLeastOnce())
+            ->method('setResult')
+            ->with($result);
+        
+        $this->processor->applyToNode($node);
+    }
+}

--- a/tests/DataEnricher/Processor/RefTest.php
+++ b/tests/DataEnricher/Processor/RefTest.php
@@ -6,9 +6,9 @@ use LegalThings\DataEnricher\Node;
 use LegalThings\DataEnricher\Processor;
 
 /**
- * @covers LegalThings\DataEnricher\Processor\JmesPath
+ * @covers LegalThings\DataEnricher\Processor\Reference
  */
-class JmesPathTest extends \PHPUnit_Framework_TestCase
+class ReferenceTest extends \PHPUnit_Framework_TestCase
 {
     public function testApplyToNode()
     {

--- a/tests/DataEnricher/Processor/RefTest.php
+++ b/tests/DataEnricher/Processor/RefTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace LegalThings\DataEnricher\Processor;
+
+use LegalThings\DataEnricher\Node;
+use LegalThings\DataEnricher\Processor;
+
+/**
+ * @covers LegalThings\DataEnricher\Processor\JmesPath
+ */
+class JmesPathTest extends \PHPUnit_Framework_TestCase
+{
+    public function testApplyToNode()
+    {
+        // for bc
+        $processor = new Processor\Reference('<ref>');
+        
+        $node = $this->createMock(Node::class);
+        
+        $data = new \stdClass;
+        $data->foo = (object)['bar' => 'crux'];
+        
+        $node->expects($this->atLeastOnce())
+            ->method('getInstruction')
+            ->with($processor)
+            ->willReturn('foo.bar');
+        
+        $node->expects($this->atLeastOnce())
+            ->method('getResult')
+            ->willReturn($data);
+        
+        $node->expects($this->atLeastOnce())
+            ->method('setResult')
+            ->with('crux');
+        
+        $processor->applyToNode($node);
+    }
+    
+    public function testApplyToNodeAsJmesPath()
+    {
+        $processor = new Processor\Reference('<ref>');
+        
+        $node = $this->createMock(Node::class);
+        
+        $data = new \stdClass;
+        $data->foo = (object)['bar' => 'crux'];
+        
+        $node->expects($this->atLeastOnce())
+            ->method('getInstruction')
+            ->with($processor)
+            ->willReturn("foo.bar=='crux'");
+        
+        $node->expects($this->atLeastOnce())
+            ->method('getResult')
+            ->willReturn($data);
+        
+        $node->expects($this->atLeastOnce())
+            ->method('setResult')
+            ->with(true);
+        
+        $processor->applyToNode($node);
+    }
+}

--- a/tests/DataEnricherTest.php
+++ b/tests/DataEnricherTest.php
@@ -175,6 +175,9 @@ class DataEnricherTest extends \PHPUnit_Framework_TestCase
                 case '<equal>':
                     $this->assertInstanceOf(Processor\Equal::class, $processor);
                     break;
+                case '<match>':
+                    $this->assertInstanceOf(Processor\Match::class, $processor);
+                    break;
             }
         }
     }

--- a/tests/DataEnricherTest.php
+++ b/tests/DataEnricherTest.php
@@ -154,6 +154,7 @@ class DataEnricherTest extends \PHPUnit_Framework_TestCase
                 case '_src':
                     $this->assertInstanceOf(Processor\Http::class, $processor);
                     break;
+                case '<apply>':
                 case '<jmespath>':
                 case '_jmespath':
                     $this->assertInstanceOf(Processor\JmesPath::class, $processor);

--- a/tests/DataEnricherTest.php
+++ b/tests/DataEnricherTest.php
@@ -172,6 +172,9 @@ class DataEnricherTest extends \PHPUnit_Framework_TestCase
                 case '<dateformat>':
                     $this->assertInstanceOf(Processor\DateFormat::class, $processor);
                     break;
+                case '<equal>':
+                    $this->assertInstanceOf(Processor\Equal::class, $processor);
+                    break;
             }
         }
     }

--- a/tests/DataEnricherTest.php
+++ b/tests/DataEnricherTest.php
@@ -178,6 +178,9 @@ class DataEnricherTest extends \PHPUnit_Framework_TestCase
                 case '<match>':
                     $this->assertInstanceOf(Processor\Match::class, $processor);
                     break;
+                case '<if>':
+                    $this->assertInstanceOf(Processor\IfElse::class, $processor);
+                    break;
             }
         }
     }


### PR DESCRIPTION
## Todo

- [ ] Data instructions are always objects with only the instruction as property. This removes the arbitrary order of execution.
- [ ] <ref> now takes a JMESPath query instead. Dot notation will also work as JMESPath query.
- [ ] Added <equal> which compares 2 values, resulting in a boolean.
- [ ] Added <match> which finds a substring or matches against a regex, resulting in a boolean.
- [ ] Removed <ifset>, use <if> instead
- [ ] Added <if> which takes a boolean as condition and has a then and else property.
<switch> now is an object with on and options, rather than using additional properties in the instruction object.
- [ ] The <enrich> instruction now has an input property, rather than using additional properties in the instruction object.
- [ ] Replaced <jmespath> with <apply>. The <apply> instruction has an input and query property.
- [ ] <merge> no longer takes strings, use <join> for strings instead.
- [ ] Added <join> instruction to join strings.
- [ ] Added <replace> instruction to find / replace in a string.
- [ ] Added <numberformat> to format number using locale.
<dateformat> may take input_format and locale.
- [ ] Renamed date property of <dateformat> to input.
- [ ] Removed <transform> instruction. Instead there are several new instructions.
- [ ] Added <hash> instruction. This supports less methods.
A <hash> instruction can have an hmac property.
- [ ] Added <encode> and <decode> instructions.
- [ ] New encode / decode methods base58 and url.
- [ ] Added <serialize> and <unserialize> instructions.
- [ ] No longer support the php serialize / unserialize methods.
- [ ] New serialize / unserialize method url. This creates an URL Query from an object.
- [ ] Added <encrypt> and <decrypt> instructions.
- [ ] Added <sign> and <verify> to create and verify a cryptographic signature.
